### PR TITLE
Extra firmware files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,18 +45,25 @@ jobs:
     - name: Build project
       run: platformio run
         
-    - name: Create firmware directory and rename firmware file
+    - name: Create firmware directory and copy firmware files
       run: |
         mkdir -p ./firmware
-        mv ./.pio/build/esp32doit-devkit-v1/firmware.bin ./firmware/firmware-v${{ steps.gitversion.outputs.semVer }}.bin
+        cp ./.pio/build/esp32doit-devkit-v1/bootloader.bin ./firmware/bootloader.bin
+        cp ./.pio/build/esp32doit-devkit-v1/partitions.bin ./firmware/partitions.bin
+        cp ${{ env.GITHUB_WORKSPACE }}/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ./firmware/boot_app0.bin
+        cp ./.pio/build/esp32doit-devkit-v1/firmware.bin ./firmware/firmware-v${{ steps.gitversion.outputs.semVer }}.bin
 
-    - name: Create Release and Upload Asset
+    - name: Create Release and Upload Assets
       uses: softprops/action-gh-release@v2
       with:
         tag_name: v${{ steps.gitversion.outputs.semVer }}
         name: Release v${{ steps.gitversion.outputs.semVer }}
         body: ${{ steps.changelog.outputs.latest_entry }}
-        files: ./firmware/firmware-v${{ steps.gitversion.outputs.semVer }}.bin
+        files: |
+          ./firmware/bootloader.bin
+          ./firmware/partitions.bin
+          ./firmware/boot_app0.bin
+          ./firmware/firmware-v${{ steps.gitversion.outputs.semVer }}.bin
         draft: false
         prerelease: false
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         cp ./.pio/build/esp32doit-devkit-v1/bootloader.bin ./firmware/bootloader.bin
         cp ./.pio/build/esp32doit-devkit-v1/partitions.bin ./firmware/partitions.bin
         cp ${{ env.GITHUB_WORKSPACE }}/.platformio/packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin ./firmware/boot_app0.bin
-        cp ./.pio/build/esp32doit-devkit-v1/firmware.bin ./firmware/firmware-v${{ steps.gitversion.outputs.semVer }}.bin
+        cp ./.pio/build/esp32doit-devkit-v1/firmware.bin ./firmware/firmware.bin
 
     - name: Create Release and Upload Assets
       uses: softprops/action-gh-release@v2
@@ -63,7 +63,7 @@ jobs:
           ./firmware/bootloader.bin
           ./firmware/partitions.bin
           ./firmware/boot_app0.bin
-          ./firmware/firmware-v${{ steps.gitversion.outputs.semVer }}.bin
+          ./firmware/firmware.bin
         draft: false
         prerelease: false
       env:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,22 +10,26 @@
 
 For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metode kræver, at Python er installeret på dit system.
 
-1. Installer esptool.py ved at køre følgende kommando:
+1. Download alle firmware-filer (bootloader.bin, partitions.bin, boot_app0.bin, og firmware.bin) fra release-siden og gem dem i samme mappe.
+
+2. Installer esptool.py ved at køre følgende kommando:
    ```
    pip install esptool
    ```
 
-2. Tilslut dit ESP32-board til din computer via USB.
+3. Tilslut dit ESP32-board til din computer via USB.
 
-3. Åbn en terminal eller kommandoprompt og naviger til mappen, der indeholder den downloadede firmware-fil.
+4. Åbn en terminal eller kommandoprompt og naviger til mappen, der indeholder de downloadede firmware-filer.
 
-4. Kør følgende kommando for at flashe firmwaren (erstat COM_PORT med din faktiske COM-port, og FIRMWARE_FILE.bin med det faktiske filnavn):
+5. Kør følgende kommando for at flashe firmwaren (erstat COM3 med din faktiske COM-port hvis nødvendigt):
    ```
-   esptool --chip esp32 --port COM_PORT --baud 115200 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x10000 FIRMWARE_FILE.bin
+   esptool --chip esp32 --port "COM3" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB 0x1000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
    ```
 
-5. Vent på at processen er færdig. Du skulle gerne se en succesmeddelelse.
+   Bemærk: Hvis kommandoen er for lang til din terminal, kan du dele den op ved at bruge `^` på Windows eller `\` på Unix-systemer ved slutningen af hver linje.
 
-6. Nulstil dit ESP32-board.
+6. Vent på at processen er færdig. Du skulle gerne se en succesmeddelelse.
 
-Denne metode giver en mere fleksibel og skriptbar tilgang til at flashe din Skumfidus-enhed.
+7. Nulstil dit ESP32-board.
+
+Denne metode sikrer, at alle nødvendige firmware-komponenter bliver flashet korrekt til din Skumfidus-enhed.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,9 +8,9 @@
 
 ## Flashning af Firmware
 
-Hvis du foretrækker at bruge kommandolinjen, kan du bruge esptool.py til at flashe firmwaren. Denne metode kræver, at Python er installeret på dit system.
+For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metode kræver, at Python er installeret på dit system.
 
-1. Installer esptool.py, hvis du ikke allerede har gjort det:
+1. Installer esptool.py ved at køre følgende kommando:
    ```
    pip install esptool
    ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,8 @@ For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metod
    For Windows (kør i cmd):
    ```
    set COM_PORT=COM3
-   esptool --chip esp32 --port %COM_PORT% --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB ^
+   set BAUD_RATE=115200
+   esptool --chip esp32 --port %COM_PORT% --baud %BAUD_RATE% --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB ^
    0x1000 bootloader.bin ^
    0x8000 partitions.bin ^
    0xe000 boot_app0.bin ^
@@ -36,7 +37,8 @@ For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metod
    For Windows (kør i PowerShell):
    ```
    $COM_PORT = "COM3"
-   esptool --chip esp32 --port $COM_PORT --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB `
+   $BAUD_RATE = 115200
+   esptool --chip esp32 --port $COM_PORT --baud $BAUD_RATE --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB `
    0x1000 bootloader.bin `
    0x8000 partitions.bin `
    0xe000 boot_app0.bin `
@@ -46,7 +48,8 @@ For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metod
    For Unix-systemer:
    ```
    export COM_PORT="/dev/ttyUSB0"
-   esptool --chip esp32 --port $COM_PORT --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB \
+   export BAUD_RATE=115200
+   esptool --chip esp32 --port $COM_PORT --baud $BAUD_RATE --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB \
    0x1000 bootloader.bin \
    0x8000 partitions.bin \
    0xe000 boot_app0.bin \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -25,7 +25,8 @@ For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metod
 
    For Windows (kør i cmd):
    ```
-   esptool --chip esp32 --port "COM3" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB ^
+   set COM_PORT=COM3
+   esptool --chip esp32 --port %COM_PORT% --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB ^
    0x1000 bootloader.bin ^
    0x8000 partitions.bin ^
    0xe000 boot_app0.bin ^
@@ -34,7 +35,8 @@ For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metod
 
    For Windows (kør i PowerShell):
    ```
-   esptool --chip esp32 --port "COM3" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB `
+   $COM_PORT = "COM3"
+   esptool --chip esp32 --port $COM_PORT --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB `
    0x1000 bootloader.bin `
    0x8000 partitions.bin `
    0xe000 boot_app0.bin `
@@ -43,7 +45,8 @@ For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metod
 
    For Unix-systemer:
    ```
-   esptool --chip esp32 --port "/dev/ttyUSB0" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB \
+   export COM_PORT="/dev/ttyUSB0"
+   esptool --chip esp32 --port $COM_PORT --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB \
    0x1000 bootloader.bin \
    0x8000 partitions.bin \
    0xe000 boot_app0.bin \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,11 +22,33 @@ For at flashe firmwaren skal du bruge esptool.py via kommandolinjen. Denne metod
 4. Åbn en terminal eller kommandoprompt og naviger til mappen, der indeholder de downloadede firmware-filer.
 
 5. Kør følgende kommando for at flashe firmwaren (erstat COM3 med din faktiske COM-port hvis nødvendigt):
+
+   For Windows (kør i cmd):
    ```
-   esptool --chip esp32 --port "COM3" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB 0x1000 bootloader.bin 0x8000 partitions.bin 0xe000 boot_app0.bin 0x10000 firmware.bin
+   esptool --chip esp32 --port "COM3" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB ^
+   0x1000 bootloader.bin ^
+   0x8000 partitions.bin ^
+   0xe000 boot_app0.bin ^
+   0x10000 firmware.bin
    ```
 
-   Bemærk: Hvis kommandoen er for lang til din terminal, kan du dele den op ved at bruge `^` på Windows eller `\` på Unix-systemer ved slutningen af hver linje.
+   For Windows (kør i PowerShell):
+   ```
+   esptool --chip esp32 --port "COM3" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB `
+   0x1000 bootloader.bin `
+   0x8000 partitions.bin `
+   0xe000 boot_app0.bin `
+   0x10000 firmware.bin
+   ```
+
+   For Unix-systemer:
+   ```
+   esptool --chip esp32 --port "/dev/ttyUSB0" --baud 460800 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size 4MB \
+   0x1000 bootloader.bin \
+   0x8000 partitions.bin \
+   0xe000 boot_app0.bin \
+   0x10000 firmware.bin
+   ```
 
 6. Vent på at processen er færdig. Du skulle gerne se en succesmeddelelse.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,30 +3,10 @@
 ## Download af Firmware
 
 1. Gå til [Skumfidus Releases-siden](https://github.com/OrangeMakers/Skumfidus/releases) på GitHub.
-2. Find den seneste udgivelse (f.eks. v0.3.0-87).
-3. Download firmware-filen (f.eks. `firmware-v0.3.0-87.bin`).
+2. Find den seneste udgivelse (Er markeret med `latest`).
+3. Download firmware-filen (f.eks. `firmware.bin`).
 
 ## Flashning af Firmware
-
-For at flashe firmwaren skal du bruge ESP32 Flash Download Tool. Hvis du ikke har det, kan du downloade det fra [Espressif-hjemmesiden](https://www.espressif.com/en/support/download/other-tools).
-
-1. Tilslut dit ESP32-board til din computer via USB.
-2. Åbn ESP32 Flash Download Tool.
-3. I værktøjet:
-   - Vælg den COM-port, som din ESP32 er tilsluttet.
-   - Indstil baud-raten til 115200.
-   - Klik på "..." knappen ved siden af det første tomme felt og vælg den downloadede firmware-fil.
-   - Indstil adressen til 0x10000.
-   - Marker boksen ved siden af firmware-filen.
-4. Klik på "Start" for at begynde flashningen.
-5. Vent på at processen er færdig. Værktøjet vil vise "FINISH", når det er færdigt.
-6. Nulstil dit ESP32-board.
-
-Din Skumfidus-enhed skulle nu køre med den seneste firmware!
-
-Bemærk: Sørg altid for at bruge den seneste firmware-version for at få den bedste ydeevne og funktioner.
-
-## Alternativ Metode: Brug af esptool.py
 
 Hvis du foretrækker at bruge kommandolinjen, kan du bruge esptool.py til at flashe firmwaren. Denne metode kræver, at Python er installeret på dit system.
 
@@ -41,7 +21,7 @@ Hvis du foretrækker at bruge kommandolinjen, kan du bruge esptool.py til at fla
 
 4. Kør følgende kommando for at flashe firmwaren (erstat COM_PORT med din faktiske COM-port, og FIRMWARE_FILE.bin med det faktiske filnavn):
    ```
-   esptool.py --chip esp32 --port COM_PORT --baud 115200 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x10000 FIRMWARE_FILE.bin
+   esptool --chip esp32 --port COM_PORT --baud 115200 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 40m --flash_size detect 0x10000 FIRMWARE_FILE.bin
    ```
 
 5. Vent på at processen er færdig. Du skulle gerne se en succesmeddelelse.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 This release introduces an alternative firmware flashing method using esptool.py, providing users with a more flexible and robust way to update their Skumfidus devices. The INSTALL.md file has been significantly updated with detailed instructions for flashing firmware on various operating systems, including Windows (using both cmd and PowerShell) and Unix-based systems. This update aims to improve the user experience and make the firmware update process more accessible to a wider range of users. Additionally, extra files have been copied to the assets in the release for improved accessibility.
 
 ### Added
-- Alternative firmware flashing method using esptool.py in INSTALL.md
+- Firmware flashing method using esptool.py in INSTALL.md
 - Detailed instructions for flashing firmware on Windows (cmd and PowerShell) and Unix systems
 - Added variables for COM_PORT and BAUD_RATE in flashing instructions
 - Extra files copied to the assets in the release

--- a/RELEASE_NEXT.md
+++ b/RELEASE_NEXT.md
@@ -1,11 +1,12 @@
 ## Description of next release
 
-This release introduces an alternative firmware flashing method using esptool.py, providing users with a more flexible and robust way to update their Skumfidus devices. The INSTALL.md file has been significantly updated with detailed instructions for flashing firmware on various operating systems, including Windows (using both cmd and PowerShell) and Unix-based systems. This update aims to improve the user experience and make the firmware update process more accessible to a wider range of users.
+This release introduces an alternative firmware flashing method using esptool.py, providing users with a more flexible and robust way to update their Skumfidus devices. The INSTALL.md file has been significantly updated with detailed instructions for flashing firmware on various operating systems, including Windows (using both cmd and PowerShell) and Unix-based systems. This update aims to improve the user experience and make the firmware update process more accessible to a wider range of users. Additionally, extra files have been copied to the assets in the release for improved accessibility.
 
 ### Added
 - Alternative firmware flashing method using esptool.py in INSTALL.md
 - Detailed instructions for flashing firmware on Windows (cmd and PowerShell) and Unix systems
 - Added variables for COM_PORT and BAUD_RATE in flashing instructions
+- Extra files copied to the assets in the release
 
 ### Changed
 - Updated INSTALL.md with more comprehensive firmware flashing instructions

--- a/RELEASE_NEXT.md
+++ b/RELEASE_NEXT.md
@@ -4,9 +4,11 @@
 
 ### Added
 - Alternative firmware flashing method using esptool.py in INSTALL.md
+- Detailed instructions for flashing firmware on Windows (cmd and PowerShell) and Unix systems
+- Added variables for COM_PORT and BAUD_RATE in flashing instructions
 
 ### Changed
-- No changes
+- Updated INSTALL.md with more comprehensive firmware flashing instructions
 
 ### Deprecated
 - No changes

--- a/RELEASE_NEXT.md
+++ b/RELEASE_NEXT.md
@@ -1,6 +1,6 @@
 ## Description of next release
 
-[Insert release description here]
+This release introduces an alternative firmware flashing method using esptool.py, providing users with a more flexible and robust way to update their Skumfidus devices. The INSTALL.md file has been significantly updated with detailed instructions for flashing firmware on various operating systems, including Windows (using both cmd and PowerShell) and Unix-based systems. This update aims to improve the user experience and make the firmware update process more accessible to a wider range of users.
 
 ### Added
 - Alternative firmware flashing method using esptool.py in INSTALL.md


### PR DESCRIPTION
This release introduces an alternative firmware flashing method using esptool.py, providing users with a more flexible and robust way to update their Skumfidus devices. The INSTALL.md file has been significantly updated with detailed instructions for flashing firmware on various operating systems, including Windows (using both cmd and PowerShell) and Unix-based systems. This update aims to improve the user experience and make the firmware update process more accessible to a wider range of users. Additionally, extra files have been copied to the assets in the release for improved accessibility.

### Added
- Firmware flashing method using esptool.py in INSTALL.md
- Detailed instructions for flashing firmware on Windows (cmd and PowerShell) and Unix systems
- Added variables for COM_PORT and BAUD_RATE in flashing instructions
- Extra files copied to the assets in the release

### Changed
- Updated INSTALL.md with more comprehensive firmware flashing instructions

### Deprecated
- No changes

### Removed
- No changes

### Fixed
- No changes

### Security
- No changes
